### PR TITLE
[feature] - adds the 'send' command to share secrets over various mediums

### DIFF
--- a/main.go
+++ b/main.go
@@ -163,7 +163,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "sctl"
 	app.Usage = "Manage secrets encrypted by KMS"
-	app.Version = "0.5.1"
+	app.Version = "0.6.0"
 
 	app.Commands = []cli.Command{
 		{
@@ -234,21 +234,6 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				// if any args present, presume decrypt
-				if len(c.Args()) >= 1 {
-					decoded, err := b64.StdEncoding.DecodeString(c.Args().First())
-					if err != nil {
-						log.Fatal(err)
-					}
-
-					cypher, err := decryptSymmetric(c.String("key"), decoded)
-					if err != nil {
-						log.Fatal(err)
-					}
-
-					fmt.Println(string(cypher))
-					return nil
-				}
 
 				plaintext := userInput()
 				if len(plaintext) == 0 {
@@ -266,9 +251,36 @@ func main() {
 				fmt.Println("Once installed, run the following commands to view this sensitive information")
 				fmt.Println("\n")
 				fmt.Println("```")
-				cmd := fmt.Sprintf("sctl send --key=%s %s", c.String("key"), encoded)
+				cmd := fmt.Sprintf("sctl receive --key=%s %s", c.String("key"), encoded)
 				fmt.Println(cmd)
 				fmt.Println("```")
+				return nil
+			},
+		},
+		{
+			Name:  "receive",
+			Usage: "Read a plaintext encoded secret",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:   "key",
+					EnvVar: "SCTL_KEY",
+					Usage:  "Gcloud KMS Key URI",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				if len(c.Args()) >= 1 {
+					decoded, err := b64.StdEncoding.DecodeString(c.Args().First())
+					if err != nil {
+						log.Fatal(err)
+					}
+
+					cypher, err := decryptSymmetric(c.String("key"), decoded)
+					if err != nil {
+						log.Fatal(err)
+					}
+
+					fmt.Println(string(cypher))
+				}
 				return nil
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -163,7 +163,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "sctl"
 	app.Usage = "Manage secrets encrypted by KMS"
-	app.Version = "0.5.0"
+	app.Version = "0.5.1"
 
 	app.Commands = []cli.Command{
 		{
@@ -224,7 +224,7 @@ func main() {
 			},
 		},
 		{
-			Name:  "slack",
+			Name:  "send",
 			Usage: "Encode/Decode a secret for copy/paste",
 			Flags: []cli.Flag{
 				cli.StringFlag{
@@ -266,7 +266,7 @@ func main() {
 				fmt.Println("Once installed, run the following commands to view this sensitive information")
 				fmt.Println("\n")
 				fmt.Println("```")
-				cmd := fmt.Sprintf("sctl slack --key=%s %s", c.String("key"), encoded)
+				cmd := fmt.Sprintf("sctl send --key=%s %s", c.String("key"), encoded)
 				fmt.Println(cmd)
 				fmt.Println("```")
 				return nil


### PR DESCRIPTION
- Tired of seeing plaintext passwords shared in slack? Yeah, me too.
  sctl wont be a silver bullet but at least it'll help reduce the
  overall footprint of having sensitive data in another walled garden
  with no delete button.
- bumps to 0.5.0

example:

```

Hello, I've shared some data with you with sctl!
https://github.com/vapor-ware/sctl
Once installed, run the following commands to view this sensitive
information

sctl slack
--key=projects/production-217413/locations/us/keyRings/operations-keyring/cryptoKeys/vapor-operations
CiQArcZm2GJg8jMXJn2+Ir4NdMuKUGRcT1MiH37suYPBhxT9EVkSTwDujG3Uc6QCD82JUPdt7YVJVJ/XnYPvIcuOzMl0TIl1WewruyoWJbfkyskhK4F06pUScRsRjZ6o+zM/KWZuV60NmwBm8o/voaJVJQXZUG0=

```