### PR TITLE
SCTL - 1.0.0-RC2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 test:
 	go test -v
 clean:
-	rm -rf dist vendor sctl parts prime stage *.snap
+	rm -rf dist vendor sctl parts prime stage *.snap *.xdelta3
 
 snap:
 	snapcraft

--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ for snaps:
 
 ```
 snap set sctl sctlkey=<YOUR_KMS_KEY_URI>
-snap connect sctl:gcloud
+gcloud auth application-default login
+mkdir -p $HOME/snaps/sctl/current/.config/gcloud
+cp $HOME/.config/gcloud/application_default_credentials.json $HOME/snaps/current/.config/gcloud/application_default_credentials.json
 ```
 
 ### Usage

--- a/command-sctl.wrapper
+++ b/command-sctl.wrapper
@@ -2,15 +2,25 @@
 
 set -eu
 
-sctlkey="$(snapctl get sctlkey)"
-if [ -z "$sctlkey" ]; then
+export SCTLKEY="$(snapctl get sctlkey)"
+if [ -z "$SCTLKEY" ]; then
     echo "sctl is not configured. Please snap set sctl sctlkey=<YOUR_KMS_KEY_URI>"
     exit 1
 fi
 
-# FIXME: Gross hack
-# Instead of deriving the GOOGLE_APPLICATION_CREDENTIAL path, allow the user to
-# set this path unless we can find a better way to grant access to these credentials
-export HOME=/home/$USER
-export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/application_default_credentials.json
+export GOOGLE_CREDENTIAL="$(snapctl get credential)"
+if [ -z "${GOOGLE_CREDENTIAL}" ]; then
+    echo "sctl is not configured. Please snap set sctl google_credential=<FILENAME_OF_CREDENTIALS.json>"
+    echo "note: this file must be present in $HOME or the /current symlinked directory"
+    echo ""
+    echo "eg:"
+    echo "gcloud auth application-default login"
+    echo "cp ~/.config/gcloud/application_default_credentials.json ~/snap/sctl/current/credentials.json"
+    echo "snap set sctl credential=credentials.json"
+
+    exit 1
+fi
+
+export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/${GOOGLE_CREDENTIAL}"
+
 exec "$SNAP/bin/sctl" "$@"

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "sctl"
 	app.Usage = "Manage secrets encrypted by KMS"
-	app.Version = "1.0.0-rc1"
+	app.Version = "1.0.0-rc2"
 
 	app.Commands = []cli.Command{
 		{

--- a/meta/hooks/configure
+++ b/meta/hooks/configure
@@ -1,9 +1,13 @@
 #!/bin/sh -e
 
-sctlkey="$(snapctl get sctlkey)"
+SCTLKEY="$(snapctl get sctlkey)"
 
-if [ -z "$sctlkey" ]; then
+if [ -z "${SCTLKEY}" ]; then
     echo "sctl is not configured. Please snap set sctl sctlkey=<YOUR_KMS_KEY_URI>"
 fi
 
-ls -al $SNAP_USER_COMMON
+GOOGLE_CREDENTIAL="$(snapctl get credential)"
+if [ -z "${GOOGLE_CREDENTIAL}" ]; then
+    echo "sctl is not configured. Please snap set sctl credential=<FILENAME_OF_CREDENTIAL.json>"
+    echo "note: this file must be present in $HOME/snap/sctl/current/"
+fi

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -20,11 +20,6 @@ parts:
     source: .
     organize:
       command-sctl.wrapper : usr/bin/sctl
-plugs:
-  gcloud:
-    interface: personal-files
-    read:
-      - $HOME/.config/gcloud
 apps:
   sctl:
     command: usr/bin/sctl
@@ -32,4 +27,3 @@ apps:
       - home
       - network
       - removable-media
-      - gcloud


### PR DESCRIPTION
- Final updates to the snap security policy
   - deprecate the personal-files interface declared in rc1
   - Add instructions on how to copy the credential into $SNAP_HOME
- Remove deltas on `make clean`
- Remove the FIXME Hack in command-sctl.wrapper