### PR TITLE
add automatic formatting and linting targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@ test:
 clean:
 	rm -rf dist vendor sctl parts prime stage *.snap *.xdelta3
 
+fmt:
+	@find . -name '*.go' -not -wholename './vendor/*' | while read -r file; do goimports -w "$$file"; done
+
+lint:
+	@golint -set_exit_status
+
 snap:
 	snapcraft
 

--- a/main.go
+++ b/main.go
@@ -3,15 +3,15 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/urfave/cli"
 	"io/ioutil"
 	"log"
 	"os"
+	"os/exec"
 	"sort"
 	"strings"
 	"time"
 
-	exec "os/exec"
+	"github.com/urfave/cli"
 )
 
 func main() {
@@ -50,11 +50,11 @@ func main() {
 				stat, _ := os.Stdin.Stat()
 				if (stat.Mode() & os.ModeCharDevice) == 0 {
 					// we presume data is being piped to stdin
-					raw_input, err := ioutil.ReadAll(os.Stdin)
+					rawInput, err := ioutil.ReadAll(os.Stdin)
 					if err != nil {
 						log.Fatal(err)
 					}
-					plaintext = bytes.TrimRight(raw_input, "\r\n")
+					plaintext = bytes.TrimRight(rawInput, "\r\n")
 				} else {
 					// we're at a terminal. data is either arg after
 					// alias or prompt the user for data.
@@ -67,17 +67,17 @@ func main() {
 						}
 					}
 				}
-				secret_name := c.Args().First()
+				secretName := c.Args().First()
 
-				secret_encoding := ""
+				secretEncoding := ""
 				// determine if we need to base64 the raw text, defaults
 				// to true.
 				if c.Bool("no-decode") == true {
 					// skip encoding, encode as plain value
-					secret_encoding = "plain"
+					secretEncoding = "plain"
 				} else {
 					// encode value as base64 compressed string
-					secret_encoding = "base64"
+					secretEncoding = "base64"
 					plaintext = []byte(b64Encode(plaintext))
 				}
 
@@ -89,13 +89,13 @@ func main() {
 				}
 				// re-encode the binary data we got back.
 				encoded := b64Encode(cypher)
-				to_add := Secret{
-					Name:       strings.ToUpper(secret_name),
+				toAdd := Secret{
+					Name:       strings.ToUpper(secretName),
 					Cyphertext: encoded,
 					Created:    time.Now(),
-					Encoding:   secret_encoding,
+					Encoding:   secretEncoding,
 				}
-				AddSecret(to_add)
+				AddSecret(toAdd)
 				return nil
 			},
 		},
@@ -163,8 +163,8 @@ func main() {
 			Name:  "rm",
 			Usage: "rm a secret",
 			Action: func(c *cli.Context) error {
-				secret_name := strings.ToUpper(c.Args().First())
-				RmSecret(secret_name)
+				secretName := strings.ToUpper(c.Args().First())
+				RmSecret(secretName)
 				return nil
 			},
 		},
@@ -174,20 +174,20 @@ func main() {
 			Action: func(c *cli.Context) error {
 				var secrets []Secret
 				secrets = ReadSecrets()
-				var known_keys = []string{}
+				var knownKeys []string
 				for _, secret := range secrets {
-					known_keys = append(known_keys, secret.Name)
+					knownKeys = append(knownKeys, secret.Name)
 				}
-				sort.Strings(known_keys)
-				for _, k := range known_keys {
+				sort.Strings(knownKeys)
+				for _, k := range knownKeys {
 					fmt.Println(k)
 				}
 				return nil
 			},
 		},
 		{
-			Name:  "run",
-			Usage: "run a command with secrets exported as env",
+			Name:           "run",
+			Usage:          "run a command with secrets exported as env",
 			SkipArgReorder: true,
 			Flags: []cli.Flag{
 				cli.StringFlag{

--- a/util.go
+++ b/util.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,16 +13,19 @@ import (
 	"time"
 
 	cloudkms "cloud.google.com/go/kms/apiv1"
-	b64 "encoding/base64"
 	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 )
 
-// Serialized secret
-// { "name": "A_SECRET",
-// "cypher": "0xD34DB33F",
-// "created": "2019-05-01 13:01:27.189242799 -0500 CDT m=+0.000075907"
-// "encoding": "plain"
-// }
+// Secret contains data and metadata related to a scuttle-managed secret.
+//
+// An example JSON-serialized secret:
+//
+//    {
+//      "name": "A_SECRET",
+//      "cypher": "0xD34DB33F",
+//      "created": "2019-05-01 13:01:27.189242799 -0500 CDT m=+0.000075907",
+//      "encoding": "plain"
+//     }
 type Secret struct {
 	Name       string    `json:"name"`
 	Cyphertext string    `json:"cypher"`
@@ -30,27 +34,27 @@ type Secret struct {
 }
 
 // AddSecret appends a secret to a given .scuttle.json file to rest
-func AddSecret(to_add Secret) {
+func AddSecret(toAdd Secret) {
 	// Adds or Updates a secret
 	var secrets = ReadSecrets()
 	for index, element := range secrets {
-		if element.Name == to_add.Name {
+		if element.Name == toAdd.Name {
 			log.Printf("Rotating entry %s", element.Name)
 			secrets[index] = secrets[len(secrets)-1] // copy last element to index i
 			secrets[len(secrets)-1] = Secret{}       // erase last element (zero value)
 			secrets = secrets[:len(secrets)-1]       // truncate slice
 		}
 	}
-	secrets = append(secrets, to_add)
+	secrets = append(secrets, toAdd)
 	WriteSecrets(secrets)
 }
 
 // RmSecret removes a secret by name from a given .scuttle.json file
-func RmSecret(secret_name string) {
+func RmSecret(secretName string) {
 	// Remove a secret from the scuttle.json
 	var secrets = ReadSecrets()
 	for index, element := range secrets {
-		if element.Name == secret_name {
+		if element.Name == secretName {
 			log.Printf("Removing entry %s", element.Name)
 			secrets[index] = secrets[len(secrets)-1] // copy last element to index i
 			secrets[len(secrets)-1] = Secret{}       // erase last element (zero value)

--- a/util_test.go
+++ b/util_test.go
@@ -31,13 +31,13 @@ func TestAddSecret_NoRotation(t *testing.T) {
 	defer patch.Unpatch()
 	defer patchWriter.Unpatch()
 
-	to_add := Secret{
+	toAdd := Secret{
 		Name:       "TEST_TO_ADD",
 		Cyphertext: "abc==",
 		Created:    time.Now(),
 	}
 
-	AddSecret(to_add)
+	AddSecret(toAdd)
 }
 
 // Test that secrets are upserted
@@ -58,13 +58,13 @@ func TestAddSecret_WithRotation(t *testing.T) {
 	defer patchWriter.Unpatch()
 	defer patchLogger.Unpatch()
 
-	to_add := Secret{
+	toAdd := Secret{
 		Name:       "A_SECRET",
 		Cyphertext: "xyz==",
 		Created:    time.Now(),
 	}
 
-	AddSecret(to_add)
+	AddSecret(toAdd)
 }
 
 // Test secret removal actually removes a secret
@@ -106,10 +106,10 @@ func TestRmSecret_NotExists(t *testing.T) {
 
 // Read the secrets from a file, and validate we have a slice of secrets
 func TestReadSecrets_ValidJson(t *testing.T) {
-	valid_json := `[{"name": "A_SECRET","cypher": "abc==", "created": "2019-07-18T09:56:53.76993767-05:00"}]`
+	validJSON := `[{"name": "A_SECRET","cypher": "abc==", "created": "2019-07-18T09:56:53.76993767-05:00"}]`
 
 	patch := monkey.Patch(ioutil.ReadFile, func(filename string) ([]byte, error) {
-		return []byte(valid_json), nil
+		return []byte(validJSON), nil
 	})
 
 	defer patch.Unpatch()
@@ -122,10 +122,10 @@ func TestReadSecrets_ValidJson(t *testing.T) {
 // Test a malformed json file. As intercepting log.Fatal is hard, all I'll check
 // for is the presence of an error
 func TestReadSecrets_InvalidJson(t *testing.T) {
-	valid_json := `[{"name": "A_SECRET" "cypher": "abc==", "created": "2019-07-18T09:56:53.76993767-05:00"}]`
+	validJSON := `[{"name": "A_SECRET" "cypher": "abc==", "created": "2019-07-18T09:56:53.76993767-05:00"}]`
 
 	patch := monkey.Patch(ioutil.ReadFile, func(filename string) ([]byte, error) {
-		return []byte(valid_json), nil
+		return []byte(validJSON), nil
 	})
 
 	fakeLogFatal := func(msg ...interface{}) {


### PR DESCRIPTION
This PR:
- adds a `fmt` make target for automated formatting & import sorting
- adds a `lint` make target to run golint
- applies formatting and linting updates

If approved, #19 should be updated to include a linting stage in CI.