### PR TITLE
Bugfix - Allow FileNotFound errors to skip raising an error

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "sctl"
 	app.Usage = "Manage secrets encrypted by KMS"
-	app.Version = "1.0.0-rc5"
+	app.Version = "1.0.0-rc6"
 
 	app.Commands = commands.BuildContextualMenu()
 

--- a/utils/state.go
+++ b/utils/state.go
@@ -28,6 +28,11 @@ func (ism IOStateManager) ReadState() (Secrets, error) {
 	file, err := ioutil.ReadFile(ism.filename)
 	// Decode the json into a slice of Secret Structs
 	if err != nil {
+		if os.IsNotExist(err) {
+			// The file doesn't exist, dont raise an error and return empty data to account
+			// for first-run without a state serialized to disk.
+			return []Secret{}, nil
+		}
 		return nil, err
 	}
 	var data []Secret


### PR DESCRIPTION
- Prior to 1.0.0 we had established a silent contract with consumers
  that sctl would be non-blocking if there were no serialized state.
  during the big refactor of 1.0.0-rc5 this contract changed to raising
  an error on file not found.

  This commit corrects the oversight on aggressively raising errors and
  restores the default behavior.