### PR TITLE
update description for EOF on macos

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -45,7 +45,7 @@ func eofKeySequenceText() string {
 	}
 
 	if runtime.GOOS == "darwin" {
-		return "⌘+D"
+		return "^+D"
 	}
 
 	return "Ctrl+D"


### PR DESCRIPTION
This PR:
- updates the string for macos EOF from `⌘+D` to `^+D`

This should #37 