### PR TITLE
update help strings for more consistent output formatting

### DIFF
--- a/commands/cli.go
+++ b/commands/cli.go
@@ -25,7 +25,7 @@ func BuildContextualMenu() []cli.Command {
 	return []cli.Command{
 		{
 			Name:  "add",
-			Usage: "add secret",
+			Usage: "Add a secret",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:   "key",
@@ -168,7 +168,7 @@ func BuildContextualMenu() []cli.Command {
 		},
 		{
 			Name:  "list",
-			Usage: "list known secrets",
+			Usage: "List known secrets",
 			Action: func(c *cli.Context) error {
 				secrets := utils.ReadSecrets()
 				var knownKeys []string
@@ -193,7 +193,7 @@ func BuildContextualMenu() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  "newkey",
-					Usage: "(optional) New KMS Key URI",
+					Usage: "New KMS Key URI (optional)",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -266,7 +266,7 @@ func BuildContextualMenu() []cli.Command {
 		},
 		{
 			Name:           "run",
-			Usage:          "run a command with secrets exported as env",
+			Usage:          "Run a command with secrets exported as env",
 			SkipArgReorder: true,
 			Flags: []cli.Flag{
 				cli.StringFlag{


### PR DESCRIPTION
This PR:
- updates some of the help strings for consistency

it should change
```
COMMANDS:
   add      add secret
   decrypt  Decrypt an encrypted secret
   encrypt  Encrypt a secret for copy/paste without storing in state
   list     list known secrets
   rekey    Re-encrypt a statefile to a new key-version
   rm       Delete a secret from state
   run      run a command with secrets exported as env
   help, h  Shows a list of commands or help for one command
```

to 

```
COMMANDS:
   add      Add secret
   decrypt  Decrypt an encrypted secret
   encrypt  Encrypt a secret for copy/paste without storing in state
   list     List known secrets
   rekey    Re-encrypt a statefile to a new key-version
   rm       Delete a secret from state
   run      Run a command with secrets exported as env
   help, h  Shows a list of commands or help for one command
```