### PR TITLE
add make target to generate html coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ stage/**
 prime/**
 bin/**
 testdata/test_writer_temp.json
+coverage.out
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 test:
-	go test -cover -v ./...
+	@ # Note: this requires go1.10+ in order to do multi-package coverage reports
+	go test -race -v -coverprofile=coverage.out -covermode=atomic ./...
+
+report:
+	@if test -f "coverage.out"; then go tool cover -html=coverage.out; else echo "run 'make test' to generate coverage file"; fi
 
 clean:
-	rm -rf dist vendor sctl sctl.exe
+	rm -rf dist vendor sctl sctl.exe coverage.out
 
 fmt:
 	@find . -name '*.go' -not -wholename './vendor/*' | while read -r file; do goimports -w "$$file"; done


### PR DESCRIPTION
This PR:
- adds a make target to generate and open an HTML coverage report
- updates the test target to generate a coverage file (and run with race detection)
- updates gitignore for coverage file


This can make it easier to find untested code paths.