### PR TITLE
update message for input termination to include Enter key

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -49,7 +49,7 @@ func eofKeySequenceText() string {
 		return "Ctrl+Z and Enter"
 	}
 
-	return "Ctrl+D"
+	return "Enter and Ctrl+D"
 }
 
 // AddSecret Recalls state if present, and appends a secret to the state file

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -38,8 +38,8 @@ func TestEOFKeySequenceText(t *testing.T) {
 		}
 	}
 
-	if current != "Ctrl+D" {
-		t.Errorf("Unexpected EOF key sequence text. Wanted: Ctrl+D Got: %v", current)
+	if current != "Enter and Ctrl+D" {
+		t.Errorf("Unexpected EOF key sequence text. Wanted: Enter and Ctrl+D Got: %v", current)
 	}
 }
 


### PR DESCRIPTION
This PR:
- updates the message for user input termination to include that the user should press Enter along with the EOF sequence.

fixes #36