### PR TITLE
propagate errors upwards instead of terminating with log.Fatal

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "sctl"
 	app.Usage = "Manage secrets encrypted by KMS"
-	app.Version = "1.2.0"
+	app.Version = "1.2.1"
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name:   "debug",

--- a/utils/configuration_test.go
+++ b/utils/configuration_test.go
@@ -9,24 +9,28 @@ func TestLoadGoodConfig(t *testing.T) {
 	c := Configuration{}
 	c.configPath = filepath.FromSlash("../testdata")
 	c.configFilePath = filepath.FromSlash(c.configPath + "/test_good_config.json")
-	c.Load()
+	err := c.Load()
+	if err != nil {
+		t.Errorf("Unexpected error during Load: %v", err)
+	}
 
 	if len(c.GoogleClient.Data) <= 1 {
 		t.Errorf("Unexpected empty client JSON. Wanted: >1 Got:  %v", len(c.GoogleClient.Data))
 	}
-
 }
 
 func TestLoadBadConfig(t *testing.T) {
 	c := Configuration{}
 	c.configPath = filepath.FromSlash("../testdata")
 	c.configFilePath = filepath.FromSlash(c.configPath + "/test_bad_config.json")
-	c.Load()
+	err := c.Load()
+	if err != nil {
+		t.Errorf("Unexpected error during Load: %v", err)
+	}
 
 	if len(c.GoogleClient.Data) != 0 {
 		t.Errorf("Unexpected empty client JSON. Wanted: 0 Got:  %v", len(c.GoogleClient.Data))
 	}
-
 }
 
 func TestLoadMissingConfig(t *testing.T) {
@@ -38,12 +42,15 @@ func TestLoadMissingConfig(t *testing.T) {
 	if err == nil {
 		t.Errorf("Unexpected success. Wanted: FileNotFound Error, Got: nil")
 	}
-
 }
+
 func TestConfigInit(t *testing.T) {
 	c := Configuration{}
 	c.configPath = filepath.FromSlash("../testdata")
-	c.Init()
+	err := c.Init()
+	if err != nil {
+		t.Errorf("Unexpected error during Init: %v", err)
+	}
 }
 
 func TestSaveConfig(t *testing.T) {
@@ -51,12 +58,19 @@ func TestSaveConfig(t *testing.T) {
 	c.configPath = filepath.FromSlash("../testdata")
 	c.configFilePath = filepath.FromSlash(c.configPath + "/test_save_config.json")
 
-	c.Save()
-
+	err := c.Save()
+	if err != nil {
+		t.Errorf("Unexpected error during Save: %v", err)
+	}
 }
 
-func TestReacConfiguration(t *testing.T) {
-	c := ReadConfiguration()
+func TestReadConfiguration(t *testing.T) {
+	c, err := ReadConfiguration()
+	if err != nil {
+		if !IsConfigLoadErr(err) {
+			t.Errorf("Unexpected error during ReadConfiguration: %v", err)
+		}
+	}
 
 	if len(c.configPath) == 0 {
 		t.Errorf("Unexpected missing ConfigPath. Wanted: not-nil Got: nil")

--- a/utils/secrets.go
+++ b/utils/secrets.go
@@ -49,7 +49,7 @@ func (s *Secrets) Add(toAdd Secret) {
 			*s = append((*s)[:index], (*s)[index+1:]...)
 		}
 	}
-	*s = append((*s), toAdd)
+	*s = append(*s, toAdd)
 }
 
 // V2 Secrets is a representation of the envelope enhanced to track their

--- a/utils/state_test.go
+++ b/utils/state_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// TestDefaultCaseFactoryIniitalizer - Test the defaults of the initiializer
+// TestDefaultCaseFactoryIniitalizer - Test the defaults of the initializer
 func TestStateManagerFactoryDefault(t *testing.T) {
 	ism := NewIOStateManager("")
 
@@ -50,10 +50,13 @@ func TestStateManagementReader(t *testing.T) {
 func TestStateManagementWriter(t *testing.T) {
 	iosm := NewIOStateManager("../testdata/test_writer_temp.json")
 
-	iosm.WriteState([]Secret{
-		Secret{Name: "TEST", Cyphertext: "ABC123", Created: time.Now()},
-		Secret{Name: "TEST2", Cyphertext: "0xD34DB33F", Created: time.Now()},
+	err := iosm.WriteState([]Secret{
+		{Name: "TEST", Cyphertext: "ABC123", Created: time.Now()},
+		{Name: "TEST2", Cyphertext: "0xD34DB33F", Created: time.Now()},
 	})
+	if err != nil {
+		t.Errorf("Unexpected error during WriteState: %v", err)
+	}
 
 	// We've written state if we got this far. Recall from disk and inspect the structure
 	secrets, err := iosm.ReadState()
@@ -72,7 +75,11 @@ func TestStateManagementWriter(t *testing.T) {
 	// Cache the value for comparison
 	firstSecretCypher := secrets[0].Cyphertext
 	secrets[0].Cyphertext = "123ABC"
-	iosm.WriteState(secrets)
+	err = iosm.WriteState(secrets)
+	if err != nil {
+		t.Errorf("Unexpected error during WriteState: %v", err)
+	}
+
 	// Recall from serialized state
 	secrets, err = iosm.ReadState()
 	if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -9,13 +9,15 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/pkg/errors"
+
 	log "github.com/sirupsen/logrus"
 )
 
 // UserInput will Display a prompt on STDOUT for data to be encrypted.
 // reads from STDIN until EOF character is received.
 // returns []byte encoded array of STDIN input.
-func UserInput(message string) []byte {
+func UserInput(message string) ([]byte, error) {
 	if message == "" {
 		message = "Enter the data you want to encrypt."
 	}
@@ -30,14 +32,14 @@ func UserInput(message string) []byte {
 			break
 		}
 		if err != nil {
-			log.Fatalf("Error on input: %s", err)
+			return nil, errors.Wrap(err, "error on user input")
 		}
 
 		// append scanned input to the array
 		lines = append(lines, line...)
 
 	}
-	return bytes.TrimRight(lines, "\r\n")
+	return bytes.TrimRight(lines, "\r\n"), nil
 }
 
 // eofKeySequenceText is a helper to determine the currently running
@@ -53,7 +55,7 @@ func eofKeySequenceText() string {
 }
 
 // AddSecret Recalls state if present, and appends a secret to the state file
-func AddSecret(toAdd Secret, keyURI string, keyCheck bool) {
+func AddSecret(toAdd Secret, keyURI string, keyCheck bool) error {
 	envelope := V2{Filepath: defaultFile}
 	envelope.KeyIdentifier = keyURI
 	nvl := NewVersionedLoader(defaultFile)
@@ -63,36 +65,35 @@ func AddSecret(toAdd Secret, keyURI string, keyCheck bool) {
 		// First run case with FileNotFound exception. Mask this and save
 		if os.IsNotExist(err) {
 			envelope.Secrets.Add(toAdd)
-			envelope.Save()
-			return
+			return envelope.Save()
 		}
 		// Handle any other parsing errors in a Fatal fashion
 		if err != nil {
-			log.WithFields(log.Fields{"method": "AddSecret"}).Fatalf("Failed parsing all known envelope formats. Failed with %v", err)
+			return errors.Wrap(err, "failed parsing all known envelope formats")
 		}
 	}
 
-	// Keycheck overrides if we bother with the key evaluation. This is problematic
+	// keyCheck overrides if we bother with the key evaluation. This is problematic
 	// when doing re-key operations on a post-v2 migrated envelope.
 	if keyCheck {
 		// If we load contents and the user has a different keyURI, intercept
 		// and warn before they save a multi-key sealed envelope of secrets
 		if !contents.SameKey(keyURI) {
-			log.Fatalf("Key mismatch detected, Refusing to save with different key identifiers. Envelope Provided: %s  User Provided: %s", contents.KeyIdentifier, keyURI)
+			return fmt.Errorf("key mismatch detected - refusing to save with different key identifiers. Envelope Provided: %s  User Provided: %s", contents.KeyIdentifier, keyURI)
 		}
 	}
 
-	jsonData, jerr := json.MarshalIndent(envelope, "", " ")
+	jsonData, err := json.MarshalIndent(envelope, "", " ")
 	// No idea how we would get here, but if this fails, we'll need to halt execution otherwise we're
 	// likely to corrupt state.
-	if jerr != nil {
-		log.Fatalf("Unable to marshall secret envelope for storage on disk. Errored with %v", jerr)
+	if err != nil {
+		return errors.Wrap(err, "unable to marshall secret envelope for storage on disk")
 	}
 	log.Debugf("Saving secret envelope with: %v", string(jsonData))
 	envelope.Secrets = contents.Secrets
 
 	envelope.Secrets.Add(toAdd)
-	envelope.Save()
+	return envelope.Save()
 }
 
 // ReadSecrets is a Wrapper to return an array of Secrets for processing
@@ -102,25 +103,21 @@ func ReadSecrets() (Secrets, string, error) {
 
 	contents, err := nvl.ReadState()
 	if err != nil {
-		log.WithFields(log.Fields{"method": "ReadSecrets"}).Fatalf("Failed parsing all known envelope formats. Failed with %v", err)
+		return nil, "", errors.Wrap(err, "failed parsing all known envelope formats")
 	}
 	return contents.Secrets, contents.KeyIdentifier, nil
 }
 
 // DeleteSecret is a Wrapper to remove a secret from state
 // toRemove - string - named key of the secret to eject from the state storage
-func DeleteSecret(toRemove string) {
+func DeleteSecret(toRemove string) error {
 	nvl := NewVersionedLoader(defaultFile)
 
 	contents, err := nvl.ReadState()
 	if err != nil {
-		log.WithFields(log.Fields{"method": "DeleteSecret"}).Warn("Failed parsing all known envelope formats.")
-		log.Fatal("Refusing to remove secret from unprocessable envelope format.")
+		return errors.Wrap(err, "failed parsing all known envelope formats - refusing to remove secret")
 	}
 	contents.Secrets.Remove(toRemove)
 	contents.Filepath = defaultFile
-	serr := contents.Save()
-	if serr != nil {
-		log.Fatalf("Failed saving file with error: %v", err)
-	}
+	return contents.Save()
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -102,6 +102,10 @@ func ReadSecrets() (Secrets, string, error) {
 	nvl := NewVersionedLoader(defaultFile)
 
 	contents, err := nvl.ReadState()
+	// First run case with FileNotFound exception. Mask this and return empty placeholders
+	if os.IsNotExist(err) {
+		return Secrets{}, "", nil
+	}
 	if err != nil {
 		return nil, "", errors.Wrap(err, "failed parsing all known envelope formats")
 	}


### PR DESCRIPTION
This PR:
- updates sctl to not use log.Fatal as a means of CLI exit on error, but to instead propagate the error up (which will ultimately be raised in a log.Fatal in the error check for cli.Run)
- updates tests accordingly
- adds error checks where they were previously missing or ignored
- some spelling fixes
- formatting

This is a first step towards making various things easier to test, in particular the CLI command actions themselves.