### PR TITLE
Add "sctl read" command.

### DIFF
--- a/commands/cli.go
+++ b/commands/cli.go
@@ -44,13 +44,14 @@ func BuildContextualMenu() []cli.Command {
 			},
 			Action: func(c *cli.Context) error {
 
+				ctxerr := validateContext(c, "add")
+				if ctxerr != nil {
+					return ctxerr
+				}
+
 				// Check for KMS key uri, and presence of the secrets name
 				var err error
 				var keyURI string
-				//:= validateContext(c, "add")
-				//if err != nil {
-				//	return err
-				//}
 
 				_, keyURI, err = utils.ReadSecrets()
 
@@ -532,15 +533,12 @@ func validateContext(c *cli.Context, context string) error {
 
 	switch context {
 	case "add":
-		// disallow empty key data
-		if len(c.String("key")) == 0 {
-			return errors.New("missing configuration for key")
-		}
 		// disallow empty secret name
 		if c.Args().First() == "" {
 			return errors.New("usage: sctl add SECRET_ALIAS")
 		}
 	case "read":
+		// disallow empty secret name
 		if c.Args().First() == "" {
 			return errors.New("usage: sctl read SECRET_ALIAS")
 		}

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "sctl"
 	app.Usage = "Manage secrets encrypted by KMS"
-	app.Version = "1.2.2"
+	app.Version = "1.3.0"
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name:   "debug",

--- a/utils/secrets.go
+++ b/utils/secrets.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -92,6 +93,17 @@ func (s *V2) SameKey(key string) bool {
 // GetVersion returns the statically declared version for the type of SecretsV2 - "2"
 func (s V2) GetVersion() string {
 	return "2"
+}
+
+// Find searches the envelope for a named string. Returns the index of the element found
+// in the envelope or -1 if not found.
+func (s *Secrets) Find(secretName string) (int, error) {
+	for i, n := range *s {
+		if secretName == n.Name {
+			return i, nil
+		}
+	}
+	return 0, errors.New("Secret not found")
 }
 
 // Load will attempt to parse the indicated Filepath from the V2 object and populate the struct

--- a/utils/secrets.go
+++ b/utils/secrets.go
@@ -2,11 +2,11 @@ package utils
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"time"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -53,6 +53,17 @@ func (s *Secrets) Add(toAdd Secret) {
 	*s = append(*s, toAdd)
 }
 
+// Find searches the envelope for a named string. Returns a secret whos name matches
+// the search term
+func (s *Secrets) Find(secretName string) (Secret, error) {
+	for _, n := range *s {
+		if secretName == n.Name {
+			return n, nil
+		}
+	}
+	return Secret{}, fmt.Errorf("Secret %s not found", secretName)
+}
+
 // V2 Secrets is a representation of the envelope enhanced to track their
 // own key URI.
 // This secret wrapper will validate that an incoming request to encrypt
@@ -93,17 +104,6 @@ func (s *V2) SameKey(key string) bool {
 // GetVersion returns the statically declared version for the type of SecretsV2 - "2"
 func (s V2) GetVersion() string {
 	return "2"
-}
-
-// Find searches the envelope for a named string. Returns the index of the element found
-// in the envelope or -1 if not found.
-func (s *Secrets) Find(secretName string) (int, error) {
-	for i, n := range *s {
-		if secretName == n.Name {
-			return i, nil
-		}
-	}
-	return 0, errors.New("Secret not found")
 }
 
 // Load will attempt to parse the indicated Filepath from the V2 object and populate the struct

--- a/utils/secrets_test.go
+++ b/utils/secrets_test.go
@@ -46,6 +46,41 @@ func TestSecretAddRotation(t *testing.T) {
 
 }
 
+func TestSecretFind(t *testing.T) {
+	s := Secrets{}
+	s.Add(Secret{
+		Name:       "TEST",
+		Cyphertext: "123TEST",
+	})
+
+	found, searchErr := s.Find("TEST")
+	if searchErr != nil {
+		t.Errorf("Unexpected error, wanted: nil Got: %v", searchErr)
+	}
+
+	if found.Name != "TEST" {
+		t.Errorf("Unexpected value, Wanted: TEST   Got: %s", found.Name)
+	}
+
+	if found.Cyphertext != "123TEST" {
+		t.Errorf("Unexpected value, Wanted: 123TEST GOT: %s", found.Cyphertext)
+	}
+}
+
+func TestSecretFindRaisesError(t *testing.T) {
+	s := Secrets{}
+	s.Add(Secret{
+		Name:       "TEST",
+		Cyphertext: "123TEST",
+	})
+
+	_, searchErr := s.Find("NO")
+	if searchErr == nil {
+		t.Error("Unexpected success, wanted: Secret Not Found Got: nil")
+	}
+
+}
+
 func TestV2SameKeyV2Migration(t *testing.T) {
 	s := V2{}
 


### PR DESCRIPTION
sctl read will scan the envelope and attempt to find the NAMED secret.
If its found, it will decode, decrypt, and display the secret value.
This is to help ease the use-case for reading secrets serialized to
state without needing to intercept the values in an intermediary
process, similar to the hacky work-around of running `sctl run env` just
to view the secrets.

This feature needs test coverage before merge.