### PR TITLE
[credentials] - Suppress output about credential source

### DIFF
--- a/credentials/gcp.go
+++ b/credentials/gcp.go
@@ -101,7 +101,7 @@ func (gc GoogleCredential) JSON() ([]byte, error) {
 	// declared credential.
 	external, exists := os.LookupEnv(CredentialVar)
 	if exists {
-		log.Printf("Using env exported %s", CredentialVar)
+		log.Debugf("Using env exported %s", CredentialVar)
 		f, err := ioutil.ReadFile(external)
 		if err != nil {
 			return []byte{}, errors.Wrapf(err, "Unable to read %s", CredentialVar)

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "sctl"
 	app.Usage = "Manage secrets encrypted by KMS"
-	app.Version = "1.3.0"
+	app.Version = "1.3.1"
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name:   "debug",


### PR DESCRIPTION
- The credential source was a big concern for me, now I just see a ton
  of spam. Moving this from a blatant Printf to a log.Debug will still
  provide the detail when required, but not spam the terminal on. every.
  use.

- Additionally pre-emptively update to 1.3.1 for a patch release