### PR TITLE
[logging] - Reduce output spam on failed update check to a debug warn.

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 		if err != nil {
 			// A failure to check should not result in a failure to use the tool. Just
 			// log the issue and continue on.
-			log.Printf("failed to check for latest version: %v", err)
+			log.Debugf("failed to check for latest version: %v", err)
 			return nil
 		}
 		if res.Outdated {


### PR DESCRIPTION
Ideally the usesr doesn't care if the update check failed, or hit API
Rate limits. These messages can be supressed to DEBUG detail.