### PR TITLE
✨ Exposes selectable envelope feature

### DIFF
--- a/commands/cli.go
+++ b/commands/cli.go
@@ -41,6 +41,11 @@ func BuildContextualMenu() []cli.Command {
 					Name:  "no-decode",
 					Usage: "When reading the secret, do not base64 decode",
 				},
+				cli.StringFlag{
+					Name:  "envelope",
+					Usage: "Filepath to envelope",
+					Value: ".scuttle.json",
+				},
 			},
 			Action: func(c *cli.Context) error {
 
@@ -53,7 +58,7 @@ func BuildContextualMenu() []cli.Command {
 				var err error
 				var keyURI string
 
-				_, keyURI, err = utils.ReadSecrets()
+				_, keyURI, err = utils.ReadSecrets(c.String("envelope"))
 
 				var plaintext []byte
 
@@ -124,7 +129,7 @@ func BuildContextualMenu() []cli.Command {
 					Encoding:   secretEncoding,
 				}
 
-				return utils.AddSecret(toAdd, keyURI, true)
+				return utils.AddSecret(toAdd, keyURI, true, c.String("envelope"))
 			},
 		},
 		{
@@ -261,8 +266,15 @@ func BuildContextualMenu() []cli.Command {
 			Name:     "list",
 			Usage:    "List known secrets",
 			Category: statecategory,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "envelope",
+					Usage: "Filepath to envelope",
+					Value: ".scuttle.json",
+				},
+			},
 			Action: func(c *cli.Context) error {
-				secrets, _, err := utils.ReadSecrets()
+				secrets, _, err := utils.ReadSecrets(c.String("envelope"))
 				if err != nil {
 					return err
 				}
@@ -287,6 +299,11 @@ func BuildContextualMenu() []cli.Command {
 					EnvVar: "SCTL_KEY",
 					Usage:  "KMS Key URI",
 				},
+				cli.StringFlag{
+					Name:  "envelope",
+					Usage: "Filepath to envelope",
+					Value: ".scuttle.json",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				// read context check only cares about the argument as a parameter
@@ -296,7 +313,7 @@ func BuildContextualMenu() []cli.Command {
 					return ctxerr
 				}
 
-				secrets, keyURI, err := utils.ReadSecrets()
+				secrets, keyURI, err := utils.ReadSecrets(c.String("envelope"))
 				if err != nil {
 					return err
 				}
@@ -361,12 +378,17 @@ func BuildContextualMenu() []cli.Command {
 					Name:  "newkey",
 					Usage: "New KMS Key URI (optional)",
 				},
+				cli.StringFlag{
+					Name:  "envelope",
+					Usage: "Filepath to envelope",
+					Value: ".scuttle.json",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				var sctlKey string
 				newKey := c.String("newkey")
 
-				secrets, keyURI, err := utils.ReadSecrets()
+				secrets, keyURI, err := utils.ReadSecrets(c.String("envelope"))
 				if err != nil {
 					return err
 				}
@@ -410,7 +432,7 @@ func BuildContextualMenu() []cli.Command {
 						log.Debug("Saving new secret: ", toAdd.Name, " With key: ", newKey)
 						// ReKeying with a new secret is an explicit process. Invoke addSecret without
 						// key validation
-						err = utils.AddSecret(toAdd, newKey, false)
+						err = utils.AddSecret(toAdd, newKey, false, c.String("envelope"))
 						if err != nil {
 							return err
 						}
@@ -431,7 +453,7 @@ func BuildContextualMenu() []cli.Command {
 						Encoding:   secret.Encoding,
 					}
 
-					err = utils.AddSecret(toAdd, sctlKey, true)
+					err = utils.AddSecret(toAdd, sctlKey, true, c.String("envelope"))
 					if err != nil {
 						return err
 					}
@@ -443,9 +465,16 @@ func BuildContextualMenu() []cli.Command {
 			Name:     "rm",
 			Usage:    "Delete a secret from state",
 			Category: statecategory,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "envelope",
+					Usage: "Filepath to envelope",
+					Value: ".scuttle.json",
+				},
+			},
 			Action: func(c *cli.Context) error {
 				secretName := strings.ToUpper(c.Args().First())
-				return utils.DeleteSecret(secretName)
+				return utils.DeleteSecret(secretName, c.String("envelope"))
 			},
 		},
 		{
@@ -463,6 +492,11 @@ func BuildContextualMenu() []cli.Command {
 					Name:  "interactive, i",
 					Usage: "Run the command in an interactive session",
 				},
+				cli.StringFlag{
+					Name:  "envelope",
+					Usage: "Filepath to envelope",
+					Value: ".scuttle.json",
+				},
 			},
 			Action: func(c *cli.Context) error {
 
@@ -476,7 +510,7 @@ func BuildContextualMenu() []cli.Command {
 				cmd := exec.Command(arguments[0], arguments[1:]...)
 				cmd.Env = os.Environ()
 				// TODO: Clean this up and handle the error case.
-				secrets, keyURI, err = utils.ReadSecrets()
+				secrets, keyURI, err = utils.ReadSecrets(c.String("envelope"))
 				if err != nil {
 					return err
 				}

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -42,9 +42,10 @@ func BuildContextualMenu() []cli.Command {
 					Usage: "When reading the secret, do not base64 decode",
 				},
 				cli.StringFlag{
-					Name:  "envelope",
-					Usage: "Filepath to envelope",
-					Value: ".scuttle.json",
+					Name:   "envelope",
+					Usage:  "Filepath to envelope",
+					EnvVar: "SCTL_ENVELOPE",
+					Value:  ".scuttle.json",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -268,9 +269,10 @@ func BuildContextualMenu() []cli.Command {
 			Category: statecategory,
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "envelope",
-					Usage: "Filepath to envelope",
-					Value: ".scuttle.json",
+					Name:   "envelope",
+					Usage:  "Filepath to envelope",
+					EnvVar: "SCTL_ENVELOPE",
+					Value:  ".scuttle.json",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -300,9 +302,10 @@ func BuildContextualMenu() []cli.Command {
 					Usage:  "KMS Key URI",
 				},
 				cli.StringFlag{
-					Name:  "envelope",
-					Usage: "Filepath to envelope",
-					Value: ".scuttle.json",
+					Name:   "envelope",
+					EnvVar: "SCTL_ENVELOPE",
+					Usage:  "Filepath to envelope",
+					Value:  ".scuttle.json",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -379,9 +382,10 @@ func BuildContextualMenu() []cli.Command {
 					Usage: "New KMS Key URI (optional)",
 				},
 				cli.StringFlag{
-					Name:  "envelope",
-					Usage: "Filepath to envelope",
-					Value: ".scuttle.json",
+					Name:   "envelope",
+					EnvVar: "SCTL_ENVELOPE",
+					Usage:  "Filepath to envelope",
+					Value:  ".scuttle.json",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -467,9 +471,10 @@ func BuildContextualMenu() []cli.Command {
 			Category: statecategory,
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "envelope",
-					Usage: "Filepath to envelope",
-					Value: ".scuttle.json",
+					Name:   "envelope",
+					EnvVar: "SCTL_ENVELOPE",
+					Usage:  "Filepath to envelope",
+					Value:  ".scuttle.json",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -493,9 +498,10 @@ func BuildContextualMenu() []cli.Command {
 					Usage: "Run the command in an interactive session",
 				},
 				cli.StringFlag{
-					Name:  "envelope",
-					Usage: "Filepath to envelope",
-					Value: ".scuttle.json",
+					Name:   "envelope",
+					EnvVar: "SCTL_ENVELOPE",
+					Usage:  "Filepath to envelope",
+					Value:  ".scuttle.json",
 				},
 			},
 			Action: func(c *cli.Context) error {

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "sctl"
 	app.Usage = "Manage secrets encrypted by KMS"
-	app.Version = "1.3.1"
+	app.Version = "1.4.0"
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name:   "debug",

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -55,17 +55,17 @@ func eofKeySequenceText() string {
 }
 
 // AddSecret Recalls state if present, and appends a secret to the state file
-func AddSecret(toAdd Secret, keyURI string, keyCheck bool) error {
-	envelope := V2{Filepath: defaultFile}
-	envelope.KeyIdentifier = keyURI
-	nvl := NewVersionedLoader(defaultFile)
+func AddSecret(toAdd Secret, keyURI string, keyCheck bool, envelope string) error {
+	stateFile := V2{Filepath: envelope}
+	stateFile.KeyIdentifier = keyURI
+	nvl := NewVersionedLoader(envelope)
 
 	contents, err := nvl.ReadState()
 	if err != nil {
 		// First run case with FileNotFound exception. Mask this and save
 		if os.IsNotExist(err) {
-			envelope.Secrets.Add(toAdd)
-			return envelope.Save()
+			stateFile.Secrets.Add(toAdd)
+			return stateFile.Save()
 		}
 		// Handle any other parsing errors in a Fatal fashion
 		if err != nil {
@@ -83,23 +83,23 @@ func AddSecret(toAdd Secret, keyURI string, keyCheck bool) error {
 		}
 	}
 
-	jsonData, err := json.MarshalIndent(envelope, "", " ")
+	jsonData, err := json.MarshalIndent(stateFile, "", " ")
 	// No idea how we would get here, but if this fails, we'll need to halt execution otherwise we're
 	// likely to corrupt state.
 	if err != nil {
 		return errors.Wrap(err, "unable to marshall secret envelope for storage on disk")
 	}
 	log.Debugf("Saving secret envelope with: %v", string(jsonData))
-	envelope.Secrets = contents.Secrets
+	stateFile.Secrets = contents.Secrets
 
-	envelope.Secrets.Add(toAdd)
-	return envelope.Save()
+	stateFile.Secrets.Add(toAdd)
+	return stateFile.Save()
 }
 
 // ReadSecrets is a Wrapper to return an array of Secrets for processing
 // Along with any KeyIdentifier found in the envelope for decryption
-func ReadSecrets() (Secrets, string, error) {
-	nvl := NewVersionedLoader(defaultFile)
+func ReadSecrets(envelope string) (Secrets, string, error) {
+	nvl := NewVersionedLoader(envelope)
 
 	contents, err := nvl.ReadState()
 	// First run case with FileNotFound exception. Mask this and return empty placeholders
@@ -114,8 +114,8 @@ func ReadSecrets() (Secrets, string, error) {
 
 // DeleteSecret is a Wrapper to remove a secret from state
 // toRemove - string - named key of the secret to eject from the state storage
-func DeleteSecret(toRemove string) error {
-	nvl := NewVersionedLoader(defaultFile)
+func DeleteSecret(toRemove string, envelope string) error {
+	nvl := NewVersionedLoader(envelope)
 
 	contents, err := nvl.ReadState()
 	if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -122,6 +122,6 @@ func DeleteSecret(toRemove string, envelope string) error {
 		return errors.Wrap(err, "failed parsing all known envelope formats - refusing to remove secret")
 	}
 	contents.Secrets.Remove(toRemove)
-	contents.Filepath = defaultFile
+	contents.Filepath = envelope
 	return contents.Save()
 }


### PR DESCRIPTION
- The stateful commands now support a flag to specify which envelope
  you'd like to operate upon, allowing for multiple sctl state files in
  a repository.

Consult:

- sctl add --help
- sctl read --help
- sctl list --help
- sctl rekey --help
- sctl rm --help