### PR TITLE
Update messaging from warn to debug

### DIFF
--- a/commands/cli.go
+++ b/commands/cli.go
@@ -102,7 +102,7 @@ func BuildContextualMenu() []cli.Command {
 				// Work with the envelope's provided key or switch to CLI flags/env
 				var client cloud.KMS
 				if keyURI == "" {
-					log.Warn("No KeyURI found in envelope. Required usage of flag/env config.")
+					log.Warn("No KeyURI found in envelope. Required usage of flag/env for SCTL_KEY.")
 					// use the switch-case to ensure we have a key set in this context
 					err := validateContext(c, "default")
 					if err != nil {
@@ -336,7 +336,7 @@ func BuildContextualMenu() []cli.Command {
 				// Work with the envelope's provided key or switch to CLI flags/env
 				var client cloud.KMS
 				if keyURI == "" {
-					log.Warn("No KeyURI found in envelope. Required usage of flag/env config.")
+					log.Debug("No KeyURI found in envelope. Required usage of flag/env for SCTL_KEY.")
 					// use the switch-case to ensure we have a key set in this context
 					err := validateContext(c, "default")
 					if err != nil {
@@ -398,7 +398,7 @@ func BuildContextualMenu() []cli.Command {
 				}
 
 				if keyURI == "" {
-					log.Debug("No KeyURI found in envelope. Using flag/env config.")
+					log.Debug("No KeyURI found in envelope. Using flag/env for SCTL_KEY.")
 					sctlKey = c.String("key")
 				} else {
 					log.Debug("Using key found in envelope: ", keyURI)
@@ -529,7 +529,7 @@ func BuildContextualMenu() []cli.Command {
 					// Work with the envelope's provided key or switch to CLI flags/env
 					var client cloud.KMS
 					if keyURI == "" {
-						log.Warn("No KeyURI found in envelope. Required usage of flag/env config.")
+						log.Debug("No KeyURI found in envelope. Required usage of flag/env for SCTL_KEY.")
 						err := validateContext(c, "run")
 						if err != nil {
 							return err

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "sctl"
 	app.Usage = "Manage secrets encrypted by KMS"
-	app.Version = "1.4.0"
+	app.Version = "1.4.1"
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name:   "debug",


### PR DESCRIPTION
- Refactored the "no key uri in envelope" messaging to be more clear
  about what it's expecting for SCTL_KEY behavior.
- Also dumped most of these to debug messaging unless you're adding,
  which we can presume will always display on a new envelope.