### PR TITLE
feat: add basic bugreport command

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+
+# These owners will be the default owners for everything in the
+# repo. Unless a later match takes precedence, owners listed here
+# will be requested for review when someone opens a pull request.
+*       @lazypower @edaniszewski
+
+# Order is important; the last matching pattern takes the most
+# precedence. Additional matches may be added below (e.g. *.py
+# for pull requests that only modify Python files).

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -564,6 +565,21 @@ func BuildContextualMenu() []cli.Command {
 					cmd.Stdin = os.Stdin
 				}
 				return cmd.Run()
+			},
+		},
+		{
+			Name:           "bugreport",
+			Usage:          "Collect system information for filing a bug report",
+			SkipArgReorder: true,
+			Action: func(c *cli.Context) error {
+				fmt.Println("File a bug for scuttle here: https://github.com/vapor-ware/sctl/issues/new")
+				fmt.Println("Include the information below to provide better context around the issue:")
+				fmt.Println("")
+				fmt.Printf("version  : %s\n", c.App.Version)
+				fmt.Printf("arch     : %s\n", runtime.GOARCH)
+				fmt.Printf("os       : %s\n", runtime.GOOS)
+				fmt.Printf("compiler : %s\n", runtime.Compiler)
+				return nil
 			},
 		},
 	}


### PR DESCRIPTION
This PR:
- adds a bugreport command to gather some system info

Not sure if there is more information that we want to capture here, but this is a start

fixes #74

```

edaniszewski ~/dev/vaporio/sctl (bugreport) ➜ ./sctl bugreport
File a bug for scuttle here: https://github.com/vapor-ware/sctl/issues/new
Include the information below to provide better context around the issue:

version  : 1.4.2
arch     : amd64
os       : darwin
compiler : gc

```