### PR TITLE
tests: update to use stretcher/testify as a test harness

### DIFF
--- a/cloud/kms_test.go
+++ b/cloud/kms_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const defaultTestKey = "projects/vapor-staging/locations/us/keyRings/sctl/cryptoKeys/sctl-dev"
@@ -33,18 +35,9 @@ func TestGCPKMSEncryptDecryptIntegration(t *testing.T) {
 	}
 
 	cypher, err := client.Encrypt([]byte("hello"))
-	if err != nil {
-		t.Fatalf("Unexpected error. Wanted: nil Got: %s", err)
-	}
+	assert.NoError(t, err)
 
 	decrypted, err := client.Decrypt(cypher)
-
-	if err != nil {
-		t.Fatalf("Unexpected error. Wanted: nil Got: %s", err)
-	}
-
-	if reflect.DeepEqual(decrypted, []byte("hello")) != true {
-		t.Fatalf("Unexpected value. Wanted: hello Got: %s", err)
-	}
-
+	assert.NoError(t, err)
+	assert.True(t, reflect.DeepEqual(decrypted, []byte("hello")))
 }

--- a/credentials/gcp_test.go
+++ b/credentials/gcp_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/zalando/go-keyring"
 	"golang.org/x/oauth2"
 )
@@ -16,33 +17,19 @@ func TestKeyringMock(t *testing.T) {
 	err := gc.SaveCredential("test", GoogleToken{ClientID: "test",
 		ClientSecret: "test",
 		RefreshToken: "test",
-		TheType:      "test_user"})
-	if err != nil {
-		t.Errorf("Unexpected error during SaveCredential: %v", err)
-	}
+		TheType:      "test_user",
+	})
+	assert.NoError(t, err)
 
 	cred, err := gc.GetCredential("test")
-	if err != nil {
-		t.Fatal("Unexpected error during GetCredential")
-	}
-
-	if cred.ClientID != "test" {
-		t.Errorf("Unexpected ClientID value. Wanted: test  Got: %v", cred.ClientID)
-	}
-	if cred.ClientSecret != "test" {
-		t.Errorf("Unexpected ClientSecret value. Wanted: test  Got: %v", cred.ClientSecret)
-	}
-	if cred.RefreshToken != "test" {
-		t.Errorf("Unexpected RefreshToken value. Wanted: test  Got: %v", cred.RefreshToken)
-	}
-	if cred.TheType != "test_user" {
-		t.Errorf("Unexpected Type value. Wanted: test_user Got: %v", cred.TheType)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "test", cred.ClientID)
+	assert.Equal(t, "test", cred.ClientSecret)
+	assert.Equal(t, "test", cred.RefreshToken)
+	assert.Equal(t, "test_user", cred.TheType)
 
 	err = gc.DeleteCredential("test")
-	if err != nil {
-		t.Errorf("Unexpected error removing credential: %v", err)
-	}
+	assert.NoError(t, err)
 }
 
 func TestKeyringMissingCredential(t *testing.T) {
@@ -50,10 +37,7 @@ func TestKeyringMissingCredential(t *testing.T) {
 	keyring.MockInit()
 
 	_, err := gc.GetCredential("nonexistant")
-
-	if err == nil {
-		t.Errorf("Unexpected success. %v", err)
-	}
+	assert.Error(t, err)
 }
 
 func TestValidateContext(t *testing.T) {
@@ -62,15 +46,11 @@ func TestValidateContext(t *testing.T) {
 	gap, exists := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS")
 	if exists {
 		err := gc.ValidateContext()
-		if err == nil {
-			t.Errorf("Unexpected success. Wanted: GOOGLE_APPLICATION_CREDENTIALS warning Got: nil,")
-		}
+		assert.Error(t, err)
 		_ = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
 	}
 	noerr := gc.ValidateContext()
-	if noerr != nil {
-		t.Errorf("Unexpected error. Wanted: nil warning Got: %v", noerr)
-	}
+	assert.NoError(t, noerr)
 
 	if exists {
 		_ = os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", gap)
@@ -86,92 +66,57 @@ func TestFormatCredential(t *testing.T) {
 		TokenType:    "test_token"}
 
 	cred, err := gc.formatCredential(&token, []byte(clientJSON))
-	if err != nil {
-		t.Fatalf("Unexpected error formatting credential: %v", err)
-	}
-
-	if cred.ClientID != "someclient.apps.googleusercontent.com" {
-		t.Errorf("Unexpected ClientID value. Wanted: someclient.apps.googleusercontent.com  Got: %v", cred.ClientID)
-	}
-
-	if cred.ClientSecret != "asecret" {
-		t.Errorf("Unexpected ClientSecret value. Wanted: asecret  Got: %v", cred.ClientSecret)
-	}
-
-	if cred.RefreshToken != "test" {
-		t.Errorf("Unexpected RefreshToken value. Wanted: test  Got: %v", cred.RefreshToken)
-	}
-
-	if cred.TheType != "authorized_user" {
-		t.Errorf("Unexpected Type value. Wanted: authorized_user  Got: %v", cred.TheType)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "someclient.apps.googleusercontent.com", cred.ClientID)
+	assert.Equal(t, "asecret", cred.ClientSecret)
+	assert.Equal(t, "test", cred.RefreshToken)
+	assert.Equal(t, "authorized_user", cred.TheType)
 }
 
 func TestJSONFromKeyring(t *testing.T) {
 	gc := GoogleCredential{}
 	_, isExist := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS")
-
 	if isExist {
 		t.Skip("Detected GOOGLE_APPLICATION_CREDENTIALS override")
 	}
+
 	keyring.MockInit()
 	err := keyring.Set("scuttle", "default-gcp", "{\"client_id\":\"test.apps.googleusercontent.com\",\"client_secret\":\"ITSASECRET\",\"refresh_token\":\"Refreshing\",\"type\":\"authorized_user\"}")
-	if err != nil {
-		t.Errorf("Unexpected error for keyring.Set: %v", err)
-	}
+	assert.NoError(t, err)
 
 	keyJSON, err := gc.JSON()
-	if err != nil {
-		t.Errorf("Unexpected error for gc.JSON: %v", err)
-	}
-	if len(keyJSON) == 0 {
-		t.Errorf("Unexpected zero-byte return. Wanted: []byte respresentation of GoogleToken. Got: []byte{}")
-	}
+	assert.NoError(t, err)
+	assert.Greater(t, len(keyJSON), 0)
 }
 
 func TestJSONFromKeyringBadCred(t *testing.T) {
 	gc := GoogleCredential{}
 	_, isExist := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS")
-
 	if isExist {
 		t.Skip("Detected GOOGLE_APPLICATION_CREDENTIALS override")
 	}
+
 	keyring.MockInit()
 
 	_, err := gc.JSON()
-
-	if err == nil {
-		t.Error("Unexpected success. Wanted: FileNotFound error, got: nil")
-	}
+	assert.Error(t, err)
 }
 
 func TestJSONFromEnv(t *testing.T) {
 	err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", filepath.FromSlash("../testdata/test_google_token.json"))
-	if err != nil {
-		t.Fatalf("failed to set test environment: %v", err)
-	}
+	assert.NoError(t, err)
 
 	gc := GoogleCredential{}
 	keyJSON, err := gc.JSON()
-	if err != nil {
-		t.Errorf("Unexpected error from gc.JSON: %v", err)
-	}
-
-	if len(keyJSON) == 0 {
-		t.Errorf("Unexpected zero-byte return.  Wanted: []byte respresentation of GoogleToken. Got: []byte{}")
-	}
+	assert.NoError(t, err)
+	assert.Greater(t, len(keyJSON), 0)
 }
 
 func TestJSONErrorFromEnv(t *testing.T) {
 	err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", filepath.FromSlash("../testdata/nonexistant.json"))
-	if err != nil {
-		t.Fatalf("failed to set test environment: %v", err)
-	}
+	assert.NoError(t, err)
 
 	gc := GoogleCredential{}
 	_, err = gc.JSON()
-
-	if err == nil {
-		t.Error("Unexected success. Wanted: FileNotFound error, got: nil")
-	}
+	assert.Error(t, err)
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
+	github.com/stretchr/testify v1.7.0
 	github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e
 	github.com/urfave/cli v1.22.1
 	github.com/zalando/go-keyring v0.0.0-20190913082157-62750a1ff80d

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e h1:IWllFTiDjjLIf2oeKxpIUmtiDV5sn71VgeQgg6vcE7k=
 github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e/go.mod h1:d7u6HkTYKSv5m6MCKkOQlHwaShTMl3HjqSGW3XtVhXM=
 github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
@@ -198,6 +200,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/utils/configuration_test.go
+++ b/utils/configuration_test.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadGoodConfig(t *testing.T) {
@@ -10,13 +12,9 @@ func TestLoadGoodConfig(t *testing.T) {
 	c.configPath = filepath.FromSlash("../testdata")
 	c.configFilePath = filepath.FromSlash(c.configPath + "/test_good_config.json")
 	err := c.Load()
-	if err != nil {
-		t.Errorf("Unexpected error during Load: %v", err)
-	}
 
-	if len(c.GoogleClient.Data) <= 1 {
-		t.Errorf("Unexpected empty client JSON. Wanted: >1 Got:  %v", len(c.GoogleClient.Data))
-	}
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, len(c.GoogleClient.Data), 1)
 }
 
 func TestLoadBadConfig(t *testing.T) {
@@ -24,13 +22,9 @@ func TestLoadBadConfig(t *testing.T) {
 	c.configPath = filepath.FromSlash("../testdata")
 	c.configFilePath = filepath.FromSlash(c.configPath + "/test_bad_config.json")
 	err := c.Load()
-	if err != nil {
-		t.Errorf("Unexpected error during Load: %v", err)
-	}
 
-	if len(c.GoogleClient.Data) != 0 {
-		t.Errorf("Unexpected empty client JSON. Wanted: 0 Got:  %v", len(c.GoogleClient.Data))
-	}
+	assert.NoError(t, err)
+	assert.Len(t, c.GoogleClient.Data, 0)
 }
 
 func TestLoadMissingConfig(t *testing.T) {
@@ -39,18 +33,15 @@ func TestLoadMissingConfig(t *testing.T) {
 	c.configFilePath = filepath.FromSlash(c.configPath + "/non_existant.json")
 	err := c.Load()
 
-	if err == nil {
-		t.Errorf("Unexpected success. Wanted: FileNotFound Error, Got: nil")
-	}
+	assert.Error(t, err)
 }
 
 func TestConfigInit(t *testing.T) {
 	c := Configuration{}
 	c.configPath = filepath.FromSlash("../testdata")
 	err := c.Init()
-	if err != nil {
-		t.Errorf("Unexpected error during Init: %v", err)
-	}
+
+	assert.NoError(t, err)
 }
 
 func TestSaveConfig(t *testing.T) {
@@ -59,20 +50,11 @@ func TestSaveConfig(t *testing.T) {
 	c.configFilePath = filepath.FromSlash(c.configPath + "/test_save_config.json")
 
 	err := c.Save()
-	if err != nil {
-		t.Errorf("Unexpected error during Save: %v", err)
-	}
+	assert.NoError(t, err)
 }
 
 func TestReadConfiguration(t *testing.T) {
 	c, err := ReadConfiguration()
-	if err != nil {
-		if !IsConfigLoadErr(err) {
-			t.Errorf("Unexpected error during ReadConfiguration: %v", err)
-		}
-	}
-
-	if len(c.configPath) == 0 {
-		t.Errorf("Unexpected missing ConfigPath. Wanted: not-nil Got: nil")
-	}
+	assert.NoError(t, err)
+	assert.NotEmpty(t, c.configPath)
 }

--- a/utils/configuration_test.go
+++ b/utils/configuration_test.go
@@ -55,6 +55,8 @@ func TestSaveConfig(t *testing.T) {
 
 func TestReadConfiguration(t *testing.T) {
 	c, err := ReadConfiguration()
-	assert.NoError(t, err)
+	if err != nil {
+		assert.True(t, IsConfigLoadErr(err))
+	}
 	assert.NotEmpty(t, c.configPath)
 }


### PR DESCRIPTION
This PR:
- adds stretcher/testify as a dependency
- updates tests to use it, as it condenses test logic, makes it slightly easier to read/write, and provides good context on test errors.