### PR TITLE
feat: add version command, get version at build time

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,10 @@ builds:
   - CGO_ENABLED=0
   ldflags:
   - -w
+  - -X github.com/vapor-ware/sctl/version.BuildDate={{ .Date }}
+  - -X github.com/vapor-ware/sctl/version.Commit={{ .ShortCommit }}
+  - -X github.com/vapor-ware/sctl/version.Tag={{ .Tag }}
+  - -X github.com/vapor-ware/sctl/version.Version={{ .Version }}
   goos:
   - linux
   - darwin

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vapor-ware/sctl/cloud"
 	"github.com/vapor-ware/sctl/credentials"
 	"github.com/vapor-ware/sctl/utils"
+	"github.com/vapor-ware/sctl/version"
 )
 
 const statecategory = "State management"
@@ -579,6 +580,21 @@ func BuildContextualMenu() []cli.Command {
 				fmt.Printf("arch     : %s\n", runtime.GOARCH)
 				fmt.Printf("os       : %s\n", runtime.GOOS)
 				fmt.Printf("compiler : %s\n", runtime.Compiler)
+				return nil
+			},
+		},
+		{
+			Name:  "version",
+			Usage: "Print build and version info",
+			Action: func(c *cli.Context) error {
+				info := version.GetVersion()
+				fmt.Println("sctl")
+				fmt.Printf("  version    : %s\n", info.Version)
+				fmt.Printf("  build date : %s\n", info.BuildDate)
+				fmt.Printf("  git commit : %s\n", info.Commit)
+				fmt.Printf("  git tag    : %s\n", info.Tag)
+				fmt.Printf("  compiler   : %s\n", info.Compiler)
+				fmt.Printf("  platform   : %s/%s\n", info.OS, info.Arch)
 				return nil
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -9,13 +9,14 @@ import (
 	"github.com/tcnksm/go-latest"
 	"github.com/urfave/cli"
 	"github.com/vapor-ware/sctl/commands"
+	"github.com/vapor-ware/sctl/version"
 )
 
 func main() {
 	app := cli.NewApp()
 	app.Name = "sctl"
 	app.Usage = "Manage secrets encrypted by KMS"
-	app.Version = "1.4.2"
+	app.Version = version.Version
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name:   "debug",

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,43 @@
+package version
+
+import (
+	"runtime"
+)
+
+// Variables describing version and build info - these should be populated
+// via build-time arguments.
+var (
+	BuildDate string
+	Commit    string
+	Tag       string
+	Version   string
+)
+
+// BinVersion describes build and version information about the binary
+// for the CLI.
+//
+// The fields for this are populated from package variables, which are
+// populated from build-time arguments.
+type BinVersion struct {
+	Arch      string
+	BuildDate string
+	Commit    string
+	Compiler  string
+	OS        string
+	Tag       string
+	Version   string
+}
+
+// GetVersion gets the build and version information, populating it with
+// package variables, populated via build-time arguments.
+func GetVersion() BinVersion {
+	return BinVersion{
+		Arch:      runtime.GOARCH,
+		BuildDate: BuildDate,
+		Commit:    Commit,
+		Compiler:  runtime.Compiler,
+		OS:        runtime.GOOS,
+		Tag:       Tag,
+		Version:   Version,
+	}
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,34 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetVersion(t *testing.T) {
+	v := GetVersion()
+
+	assert.Equal(t, "", v.BuildDate)
+	assert.Equal(t, "", v.Commit)
+	assert.Equal(t, "", v.Tag)
+	assert.Equal(t, "", v.Version)
+	assert.NotEmpty(t, v.Arch)
+	assert.NotEmpty(t, v.OS)
+	assert.NotEmpty(t, v.Compiler)
+}
+
+func TestGetVersion2(t *testing.T) {
+	Commit = "123"
+	Tag = "tag-1"
+
+	v := GetVersion()
+
+	assert.Equal(t, "", v.BuildDate)
+	assert.Equal(t, "123", v.Commit)
+	assert.Equal(t, "tag-1", v.Tag)
+	assert.Equal(t, "", v.Version)
+	assert.NotEmpty(t, v.Arch)
+	assert.NotEmpty(t, v.OS)
+	assert.NotEmpty(t, v.Compiler)
+}


### PR DESCRIPTION
This PR:
- gets the version at build time - this means versions are based on the git tag, and we no longer have to go in and manually update the version string within the application itself
- adds version command to provide some additional version+build information c
- adds tests