### PR TITLE
feat: read via list index

### DIFF
--- a/commands/cli.go
+++ b/commands/cli.go
@@ -268,9 +268,8 @@ func BuildContextualMenu() []cli.Command {
 			},
 		},
 		{
-			Name:  "list",
-			Usage: "List known secrets",
-
+			Name:     "list",
+			Usage:    "List known secrets",
 			Category: statecategory,
 			Flags: []cli.Flag{
 				cli.StringFlag{

--- a/commands/cli.go
+++ b/commands/cli.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -267,8 +268,9 @@ func BuildContextualMenu() []cli.Command {
 			},
 		},
 		{
-			Name:     "list",
-			Usage:    "List known secrets",
+			Name:  "list",
+			Usage: "List known secrets",
+
 			Category: statecategory,
 			Flags: []cli.Flag{
 				cli.StringFlag{
@@ -288,8 +290,8 @@ func BuildContextualMenu() []cli.Command {
 					knownKeys = append(knownKeys, secret.Name)
 				}
 				sort.Strings(knownKeys)
-				for _, k := range knownKeys {
-					fmt.Println(k)
+				for i, k := range knownKeys {
+					fmt.Printf("%d] %s\n", i, k)
 				}
 				return nil
 			},
@@ -325,6 +327,19 @@ func BuildContextualMenu() []cli.Command {
 				}
 
 				searchTerm := c.Args().First()
+
+				if idx, err := strconv.Atoi(searchTerm); err == nil {
+					var knownKeys []string
+					for _, secret := range secrets {
+						knownKeys = append(knownKeys, secret.Name)
+					}
+					sort.Strings(knownKeys)
+
+					if idx >= len(knownKeys) {
+						return errors.New("invalid read index specified")
+					}
+					searchTerm = knownKeys[idx]
+				}
 
 				locatedSecret, findErr := secrets.Find(strings.ToUpper(searchTerm))
 				if findErr != nil {


### PR DESCRIPTION
This PR:
- adds a feature to allow reading values in an envelope via index. since `sctl list` sorts responses, we can use that sorted index as a reference to a key. this is a convenience if you are lazy like me and dont want to copy/paste or type the whole thing out.

```
$ sctl add --key my/key FOO bar

$ sctl add hello world

$ sctl list
0] FOO
1] HELLO

$ sctl read foo
bar

$ sctl read hello
world

$ sctl read 0
bar

$ sctl read 1
world

$ sctl read 2
FATA[0000] invalid read index specified
```

If there are objections, I'm a-ok with this not landing. (: