### PR TITLE
Implement loopback OAUTH flow

### DIFF
--- a/commands/cli.go
+++ b/commands/cli.go
@@ -151,6 +151,14 @@ func BuildContextualMenu() []cli.Command {
 				{
 					Name:  "add",
 					Usage: "Add a default credential",
+					Flags: []cli.Flag{
+						cli.IntFlag{
+							Name:  "port",
+							Usage: "The port to listen on for the oauth callback",
+							Value: 9999,
+						},
+					},
+
 					Action: func(c *cli.Context) error {
 						var cred credentials.GoogleCredential
 						conf, err := utils.ReadConfiguration()
@@ -173,7 +181,9 @@ func BuildContextualMenu() []cli.Command {
 							conf.GoogleClient = utils.Client{Data: string(clientData)}
 						}
 
-						err = cred.Login(conf, "default")
+						port := c.Int("port")
+
+						err = cred.Login(conf, "default", port)
 						if err != nil {
 							return err
 						}


### PR DESCRIPTION
The OOB OAUTH flow we were using was discontinued by Google in October 2022
[oob-migration](https://developers.google.com/identity/protocols/oauth2/resources/oob-migration).

This PR implements the loopback flow recommended for Desktop clients
[oob-migration/desktop-client](https://developers.google.com/identity/protocols/oauth2/resources/oob-migration#desktop-client), fixing the current sctl breakage.

This doesn't make the headless workflow any easier; that might require a service-account and the [server-to-server](https://developers.google.com/identity/protocols/oauth2/service-account) flow.